### PR TITLE
Updated api logging

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,7 +12,6 @@
         "@badgateway/oauth2-client": "^2.0.18",
         "@google-cloud/pubsub": "^4.3.3",
         "@types/express": "^4.17.17",
-        "@types/morgan": "^1.9.4",
         "axios": "^1.6.0",
         "body-parser": "^1.20.2",
         "dayjs": "^1.11.7",
@@ -20,7 +19,7 @@
         "express": "^4.19.2",
         "express-rate-limit": "^7.2.0",
         "firebase-admin": "^12.0.0",
-        "morgan": "^1.10.0"
+        "winston": "^3.13.0"
       },
       "devDependencies": {
         "@types/node": "^18.15.11",
@@ -38,6 +37,14 @@
         "node": ">= 14"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -48,6 +55,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -480,14 +497,6 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
     },
-    "node_modules/@types/morgan": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.4.tgz",
-      "integrity": "sha512-cXoc4k+6+YAllH3ZHmx4hf7La1dzUk6keTR4bF4b4Sc0mZxU/zK4wO7l+ZzezXm/jkYj/qC+uYGZrarZdIVvyQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "18.15.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
@@ -540,6 +549,11 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -656,6 +670,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -704,22 +723,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/basic-auth/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
@@ -889,6 +892,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -904,6 +916,37 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1081,6 +1124,11 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -1266,6 +1314,11 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1339,6 +1392,11 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
@@ -1673,6 +1731,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1824,6 +1887,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "node_modules/limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
@@ -1848,6 +1916,22 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+    },
+    "node_modules/logform": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+      "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/long": {
       "version": "5.2.3",
@@ -1969,45 +2053,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
-    },
-    "node_modules/morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
-      "dependencies": {
-        "basic-auth": "~2.0.1",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/morgan/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/morgan/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/morgan/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -2210,20 +2255,20 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/p-defer": {
@@ -2509,6 +2554,14 @@
         }
       ]
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2655,6 +2708,14 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
@@ -2674,6 +2735,14 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/statuses": {
@@ -2812,6 +2881,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2848,6 +2922,14 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
@@ -3024,6 +3106,40 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
+      "integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
+      "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,6 @@
     "@badgateway/oauth2-client": "^2.0.18",
     "@google-cloud/pubsub": "^4.3.3",
     "@types/express": "^4.17.17",
-    "@types/morgan": "^1.9.4",
     "axios": "^1.6.0",
     "body-parser": "^1.20.2",
     "dayjs": "^1.11.7",
@@ -25,7 +24,7 @@
     "express": "^4.19.2",
     "express-rate-limit": "^7.2.0",
     "firebase-admin": "^12.0.0",
-    "morgan": "^1.10.0"
+    "winston": "^3.13.0"
   },
   "devDependencies": {
     "@types/node": "^18.15.11",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -9,6 +9,7 @@ import oauthRouter from "./routes/oauth.routes";
 import summaryRouter from "./routes/summary.routes";
 import webhookRouter from "./routes/webhook.routes";
 import RateLimiter from "express-rate-limit";
+import logger from "./util/logger";
 
 const app = express();
 
@@ -23,7 +24,7 @@ const limiter = RateLimiter({
   //snippet from https://github.com/express-rate-limit/express-rate-limit/wiki/Troubleshooting-Proxy-Issues
   keyGenerator(request: any, _response: any): string {
     if (!request.ip) {
-      console.error("Warning: request.ip is missing!");
+      logger.warn("request.ip is missing!");
       return request.socket.remoteAddress;
     }
     return request.ip.replace(/:\d+[^:]*$/, "");
@@ -48,5 +49,5 @@ app.use("/webhooks", webhookRouter);
 const port = process.env.PORT || 3000;
 
 app.listen(port, () => {
-  console.log(`Server running on port ${port}`);
+  logger.info(`Server running`, { port });
 });

--- a/api/src/lib/oauth/FitbitOauthClient.ts
+++ b/api/src/lib/oauth/FitbitOauthClient.ts
@@ -1,6 +1,7 @@
 import { OAuth2Client, generateCodeVerifier } from "@badgateway/oauth2-client";
 import axios from "axios";
 import UserService from "../services/user";
+import logger from "../../util/logger";
 
 const FITBIT_AUTH_URL = "https://www.fitbit.com/oauth2/authorize";
 const FITBIT_TOKEN_URL = "https://api.fitbit.com/oauth2/token";
@@ -43,7 +44,7 @@ const FitbitOauthClient = {
       const tokenResponse = await axios.post(tokenUrl, payload, config);
       return tokenResponse.data;
     } catch (error: any) {
-      console.error(error.name, error.code, error.message, error.response.data);
+      logger.error(error);
       throw new Error("Failed to fetch tokens");
     }
   },

--- a/api/src/lib/oauth/WhoopOauthClient.ts
+++ b/api/src/lib/oauth/WhoopOauthClient.ts
@@ -1,6 +1,7 @@
 import { OAuth2Client } from "@badgateway/oauth2-client";
 import axios from "axios";
 import UserService from "../services/user";
+import logger from "../../util/logger";
 
 const WHOOP_AUTH_URL = "https://api.prod.whoop.com/oauth/oauth2/auth";
 const WHOOP_TOKEN_URL = "https://api.prod.whoop.com/oauth/oauth2/token";
@@ -80,7 +81,7 @@ const WhoopOauthClient = {
 
       return tokens.access_token;
     } catch (error) {
-      console.error("Failed to refresh token", error);
+      logger.error("Failed to refresh token", error);
     }
   },
 };

--- a/api/src/lib/services/fitbit.ts
+++ b/api/src/lib/services/fitbit.ts
@@ -119,12 +119,10 @@ const FitbitService = (tokens: {
   };
   const getSummary = async (date: string) => {
     const hrvData = await FitbitApi(tokens).fetchHrvData(date);
-    console.log(hrvData);
     return hrvData;
   };
   const subscribeToActivities = async () => {
     const status = await FitbitApi(tokens).subscribeToActivities();
-    console.log(status);
   };
   return {
     getUser,

--- a/api/src/lib/services/publish.ts
+++ b/api/src/lib/services/publish.ts
@@ -1,4 +1,5 @@
 import { PubSub } from "@google-cloud/pubsub";
+import logger from "../../util/logger";
 
 // Create a new instance of the PubSub client
 const pubsub = new PubSub();
@@ -14,15 +15,16 @@ async function publishMessage(
   try {
     const topic = pubsub.topic(topicName);
 
-    if (typeof message === "object") {
-      message = JSON.stringify(message);
-    }
+    await topic.publishMessage({
+      json: message,
+    });
 
-    await topic.publish(Buffer.from(message));
-
-    console.log(`Message published to topic: ${topicName}`);
+    logger.info("Published message", {
+      topic: topic.name,
+      pubsubData: message,
+    });
   } catch (error) {
-    console.error("Error publishing message:", error);
+    logger.error("Error publishing message", error);
   }
 }
 

--- a/api/src/lib/services/user.ts
+++ b/api/src/lib/services/user.ts
@@ -1,5 +1,6 @@
 import { FitnessUpdateTypes, WebhookTypes } from "../../types/api";
 import { WhoopWorkoutData } from "../../types/whoop";
+import logger from "../../util/logger";
 import DB from "../db";
 import FitbitService from "./fitbit";
 import WhoopService from "./whoop";
@@ -104,7 +105,7 @@ const UserService = {
           throw new Error("Provider not supported");
       }
     } catch (error: any) {
-      console.error(error.response);
+      logger.error(error);
     }
     return activity;
   },

--- a/api/src/lib/services/whoop.ts
+++ b/api/src/lib/services/whoop.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import dayjs from "dayjs";
 import { WhoopOauthClient } from "../oauth";
 import { WhoopWorkoutMap } from "../../types/whoop";
+import logger from "../../util/logger";
 
 const WhoopApi = async (
   tokenFunction: () => Promise<{ access_token: string; refresh_token: string }>
@@ -105,8 +106,8 @@ const WhoopService = (
     sleep.sleepScore = sleep.score;
     delete sleep.score;
 
-    if (!recovery) console.error(`Summary for ${date} not found.`);
-    if (!sleep) console.error(`Sleep for ${date} not found.`);
+    if (!recovery) logger.error(`Summary not found.`, { date });
+    if (!sleep) logger.error(`Sleep not found`, { date });
 
     const summary = {
       ...recovery,

--- a/api/src/routes/oauth.routes.ts
+++ b/api/src/routes/oauth.routes.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import UserService from "../lib/services/user";
 import FitbitService from "../lib/services/fitbit";
 import WhoopService from "../lib/services/whoop";
+import logger from "../util/logger";
 
 const oauthRouter = Router();
 
@@ -40,7 +41,7 @@ oauthRouter.post("/fitbit/auth", async (req, res) => {
     await UserService.create(email, userData);
     res.status(201).json({ email, provider: userData.provider });
   } catch (error) {
-    console.error(error);
+    logger.error(error);
     return res.status(500).send("Something went wrong");
   }
 });

--- a/api/src/util/logger.ts
+++ b/api/src/util/logger.ts
@@ -1,0 +1,22 @@
+import winston from "winston";
+
+const format = winston.format((info) => {
+  return {
+    ...info,
+    severity: info.level,
+  };
+});
+
+const logger = winston.createLogger({
+  transports: [
+    new winston.transports.Console({
+      format: winston.format.combine(
+        winston.format.timestamp(),
+        format(),
+        winston.format.json()
+      ),
+    }),
+  ],
+});
+
+export default logger;

--- a/fe-auth/src/routes/api/auth/whoop/+server.ts
+++ b/fe-auth/src/routes/api/auth/whoop/+server.ts
@@ -7,8 +7,6 @@ export async function GET() {
 
     return new Response(JSON.stringify({ url: authUrl }));
   } catch (err) {
-    console.log(err);
-
     throw error(500, "failed to fetch auth code");
   }
 }


### PR DESCRIPTION
Implements `winston` logging to be consumed by gcp for api service. Replaces instances of `console.*` with `logger.*`.
Service logs should now be cleanly visible in log explorer.
<img width="562" alt="image" src="https://github.com/Deogle/helth-service/assets/14980282/c398f52a-5c1c-4257-91d1-8b42e990cf66">

Resolves #28 